### PR TITLE
Move to the new style static knockout scheduler format

### DIFF
--- a/schedule.yaml
+++ b/schedule.yaml
@@ -97,53 +97,58 @@ knockout:
     arenas:
     - A
 static_knockout:
-  matches:
-    # 'round' number
+  rounds:
+    # round number
     0:
-      # match number within the round
-      0:
-        arena: A
-        display_name: Qualifier 1
-        start_time: 2018-04-15 15:30:00+01:00
-        # S<num> means seed number
-        teams:
-        - S3
-        - S5
-        - S8
-        - S10
-      1:
-        arena: A
-        display_name: Qualifier 2
-        start_time: 2018-04-15 15:35:00+01:00
-        teams:
-        - S4
-        - S6
-        - S7
-        - S9
+      display_name: Heats
+      matches:
+        # match number within the round
+        0:
+          arena: A
+          display_name: Qualifier 1
+          start_time: 2018-04-15 15:30:00+01:00
+          # S<num> means seed number
+          teams:
+          - S3
+          - S5
+          - S8
+          - S10
+        1:
+          arena: A
+          display_name: Qualifier 2
+          start_time: 2018-04-15 15:35:00+01:00
+          teams:
+          - S4
+          - S6
+          - S7
+          - S9
     1:
-      0:
-        arena: A
-        start_time: 2018-04-15 15:45:00+01:00
-        # 012 means the 3rd place in match 1 in round 0 of the knockouts
-        teams:
-        - S2
-        - '000'
-        - '002'
-        - '011'
-      1:
-        arena: A
-        start_time: 2018-04-15 15:50:00+01:00
-        teams:
-        - S1
-        - '001'
-        - '010'
-        - '012'
+      matches:
+        0:
+          arena: A
+          start_time: 2018-04-15 15:45:00+01:00
+          # 012 means the 3rd place in match 1 in round 0 of the knockouts
+          teams:
+          - S2
+          - '000'
+          - '002'
+          - '011'
+        1:
+          arena: A
+          start_time: 2018-04-15 15:50:00+01:00
+          teams:
+          - S1
+          - '001'
+          - '010'
+          - '012'
     2:
-      0:
-        arena: A
-        start_time: 2018-04-15 16:00:00+01:00
-        teams:
-        - '100'
-        - '101'
-        - '110'
-        - '111'
+      display_name: Finals
+      matches:
+        0:
+          arena: A
+          start_time: 2018-04-15 16:00:00+01:00
+          teams:
+          - '100'
+          - '101'
+          - '110'
+          - '111'


### PR DESCRIPTION
Runs the new command from https://github.com/PeterJCLaw/srcomp-cli/pull/45 so we're using the new format introduced in https://github.com/PeterJCLaw/srcomp/commit/5eca5ec3f31b44927e5ae3761f2de921b127d9f9.

The old format is still supported, but this new format makes adding round-level keys easier.